### PR TITLE
fix: unbreak the daily image-build CI (rig-debian, duckdb4, dbi)

### DIFF
--- a/.github/ARCHITECTURE_SUPPORT.md
+++ b/.github/ARCHITECTURE_SUPPORT.md
@@ -54,8 +54,10 @@ The `rig-debian` image is restricted to `amd64` only:
 ```dockerfile
 # arch: amd64
 
-# Before changing this to 24.04, check if pak install from binary
-FROM debian:bookworm
+# Debian Trixie (13): Posit's CDN only publishes the latest R release for
+# recent Debian versions. Bookworm (12) stopped at R 4.6.0 (rig add release
+# then 403s on R 4.6.1), so Trixie is required for `rig add release` to work.
+FROM debian:trixie
 ```
 
 This means:

--- a/DOCKER_DEPENDENCY_ANALYSIS.md
+++ b/DOCKER_DEPENDENCY_ANALYSIS.md
@@ -24,7 +24,7 @@
 ✓ forky-gcc-rig-rdev-duckdb ← forky-gcc-rig-rdev ← ghcr.io/cynkra/docker-images/forky-gcc-rig-rdev:latest
 ✓ r-minimal ← ubuntu:latest (external)
 ✓ rchk-igraph ← kalibera/rchk:latest (external)
-✓ rig-debian ← debian:bookworm (external)
+✓ rig-debian ← debian:trixie (external)
 ✓ rig-rocky8 ← rockylinux:8 (external)
 ✓ rig-ubuntu ← ubuntu:22.04 (external)
 ✓ rig-ubuntu-dbi ← rig-ubuntu ← ghcr.io/cynkra/docker-images/rig-ubuntu:latest
@@ -113,7 +113,7 @@
 ### FROM Dependencies
 
 - `almalinux/9-base` used by: alma9
-- `debian:bookworm` used by: rig-debian
+- `debian:trixie` used by: rig-debian
 - `debian:forky` used by: forky
 - `kalibera/rchk:latest` used by: rchk-igraph
 - `rhub/clang18` used by: clang18-duckdb
@@ -138,7 +138,7 @@ This section shows the expected FROM instructions based on directory hierarchy:
 - `forky-gcc-rig-rdev-duckdb`: FROM `ghcr.io/cynkra/docker-images/forky-gcc-rig-rdev:latest` ✓
 - `r-minimal` (root): FROM `ubuntu:latest` ✓
 - `rchk-igraph` (root): FROM `kalibera/rchk:latest` ✓
-- `rig-debian` (root): FROM `debian:bookworm` ✓
+- `rig-debian` (root): FROM `debian:trixie` ✓
 - `rig-rocky8` (root): FROM `rockylinux:8` ✓
 - `rig-ubuntu` (root): FROM `ubuntu:22.04` ✓
 - `rig-ubuntu-dbi`: FROM `ghcr.io/cynkra/docker-images/rig-ubuntu:latest` ✓

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ R check environment with igraph dependencies, based on kalibera/rchk. Includes l
 
 ### [rig-debian](rig-debian)
 
-**Dependency**: debian:bookworm
-Debian Bookworm-based rig environment for compatibility testing and specialized Debian workflows.
+**Dependency**: debian:trixie
+Debian Trixie-based rig environment for compatibility testing and specialized Debian workflows.
 
 ### [rig-rocky8](rig-rocky8)
 
@@ -157,7 +157,7 @@ DuckDB development environment with build tools (python3, ninja-build, cmake) an
 ### [rig-ubuntu/duckdb4](rig-ubuntu/duckdb4)
 
 **Dependency**: rig-ubuntu
-Like rig-ubuntu/duckdb, but with R 4.1.3 for compatibility testing. Includes duckdb, cpp11, decor, and devtools packages.
+Like rig-ubuntu/duckdb, but with R 4.2.3 for compatibility testing. Includes duckdb, cpp11, decor, and devtools packages.
 
 ### [rig-ubuntu/duckdb/dev](rig-ubuntu/duckdb/dev)
 

--- a/rig-debian/Dockerfile
+++ b/rig-debian/Dockerfile
@@ -1,7 +1,9 @@
 # arch: amd64
 
-# Before changing this to 24.04, check if pak install from binary
-FROM debian:bookworm
+# Debian Trixie (13): Posit's CDN only publishes the latest R release for
+# recent Debian versions. Bookworm (12) stopped at R 4.6.0 (rig add release
+# then 403s on R 4.6.1), so Trixie is required for `rig add release` to work.
+FROM debian:trixie
 
 RUN \
   apt-get update && \

--- a/rig-ubuntu/dbi/Dockerfile
+++ b/rig-ubuntu/dbi/Dockerfile
@@ -6,6 +6,11 @@ FROM ghcr.io/cynkra/docker-images/rig-ubuntu:latest
 RUN \
   apt-get update && \
   apt-get install -y gnupg lsb-release time && \
+  # Pre-install cpp11 first: right after a new R release, P3M may not have a
+  # binary yet for packages that LinkingTo cpp11 (e.g. timechange), so pak
+  # builds them from source and needs cpp11 already present in the library.
+  R       -q -e 'pak::pak("cpp11")' && \
+  R-devel -q -e 'pak::pak("cpp11")' && \
   R       -q -e 'pak::pak(c("DBI", "RMariaDB", "RPostgres", "RSQLite", "dm", "duckdb", "odbc", "adbi", "cpp11", "devtools", "decor", "reprex"), dependencies = TRUE)' && \
   R-devel -q -e 'pak::pak(c("DBI", "RMariaDB", "RPostgres", "RSQLite", "dm", "duckdb", "odbc", "adbi", "cpp11", "devtools", "decor", "reprex"), dependencies = TRUE)' && \
   rm -rf /var/lib/apt/lists/* && \

--- a/rig-ubuntu/duckdb4/Dockerfile
+++ b/rig-ubuntu/duckdb4/Dockerfile
@@ -2,12 +2,13 @@
 
 FROM ghcr.io/cynkra/docker-images/rig-ubuntu:latest
 
-# Install system dependencies, R 4.1, and R packages, then clean up
+# Install system dependencies, R 4.2, and R packages, then clean up
+# R 4.2 is the oldest R still supported by duckdb (Depends: R >= 4.2.0).
 RUN \
   apt-get update && \
   apt-get install -y python3 ninja-build cmake && \
-  rig add 4.1 && \
-  R-4.1.3 -q -e 'pak::pak(c("duckdb", "cpp11", "decor", "devtools"), dependencies = TRUE)' && \
+  rig add 4.2 && \
+  R-4.2.3 -q -e 'pak::pak(c("duckdb", "cpp11", "decor", "devtools"), dependencies = TRUE)' && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /tmp/* && \
   rm -rf /var/tmp/* && \


### PR DESCRIPTION
## Why

The scheduled **"Create and publish a Docker image"** workflow has failed **every day for 8+ days**. The aggregate `CI` job fails whenever any build fails, and three amd64 image builds break deterministically — each caused by an upstream change, surfaced daily because the `rig-ubuntu` base rebuilds via `date.txt` and cascades a full rebuild into its children. (The sporadic arm64 failures seen on some days are unrelated transient runner flakiness and are not addressed here.)

## Fixes

- **rig-debian** — `rig add release` resolves to R 4.6.1, but Posit's CDN publishes no Debian 12 (Bookworm) build of it (HTTP 403); Bookworm stops at R 4.6.0. Debian 13 (Trixie) serves R 4.6.1 and devel, so the base image is switched to `debian:trixie`.

- **rig-ubuntu/duckdb4** — the image pinned R 4.1.3, but current CRAN `duckdb` (1.5.4.3) requires `R (>= 4.2.0)`, so pak could not solve. Bumped to R 4.2.3 — the oldest R duckdb still supports — preserving the image's "oldest supported R" purpose.

- **rig-ubuntu/dbi** — on the freshly released R 4.6.1, P3M had no binary for `timechange` yet, so pak built it from source and failed because its `LinkingTo` dependency `cpp11` was not yet installed. `cpp11` is now pre-installed for both `R` and `R-devel` before the main install.

## Docs

`README.md`, `DOCKER_DEPENDENCY_ANALYSIS.md`, and `.github/ARCHITECTURE_SUPPORT.md` updated to match the new base image and R versions. `DOCKER_DEPENDENCY_ANALYSIS.md` is normally generated, but its generator lives in the `../github-docker` repo (not available in this session); the base-image string swap is identical to what the generator would produce. No other generated files (`stages.yml`, per-directory Makefiles) needed changes — paths, image names, and `# arch:` comments are unchanged.

## Verification note

Root causes and fixes were validated against the live Posit CDN / P3M / CRAN endpoints (Debian-13 R 4.6.1 available; duckdb needs ≥ 4.2; R 4.2.3 available). A full local Docker build could not be run to confirm — the session's egress policy blocks GitHub release downloads and ghcr blob storage, which the rig install and base image require. The rig-debian and duckdb4 fixes follow directly from confirmed upstream availability; the dbi fix targets pak's source-build ordering, which could not be reproduced in a container here.

https://claude.ai/code/session_015yTvjHe8HbC8YtfmqHVTYx

🤖 Generated with [Claude Code](https://claude.com/claude-code)